### PR TITLE
Remove fixed project name from compose file and document project naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ sudo chmod 0640 filebeat/filebeat.yml
 
 # 4) Bring the stack up
 docker compose up -d
+# To keep a fixed project name (for consistent container names):
+#   COMPOSE_PROJECT_NAME=observability-stack-master docker compose up -d
+# or:
+#   docker compose -p observability-stack-master up -d
 
 # 5) (Optional, once) Load Filebeat/Kibana assets
 docker exec -it observability-stack-master-filebeat-1 filebeat test config -e

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-name: observability-stack-master
-
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0


### PR DESCRIPTION
## Summary
- drop explicit project `name` from `docker-compose.yml`
- document how to set a project name via `COMPOSE_PROJECT_NAME` or `-p`

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bda660e99083309a5616e96b31e44a